### PR TITLE
Add cuda as Conda dependency to environment.yml file

### DIFF
--- a/modules/local/chai_1/environment.yml
+++ b/modules/local/chai_1/environment.yml
@@ -1,9 +1,12 @@
 channels:
-- conda-forge
-- bioconda
+  - conda-forge
+  - bioconda
+  - nvidia
 dependencies:
-- gcc_linux-64=14.1.0
-- python=3.12
-- pip
-- pip:
-  - chai_lab==0.3.0
+  - gcc_linux-64=14.1.0
+  - python=3.12
+  - cuda=12.1
+  # - cudatoolkit=12.1 # It possibly needs this but not in the documentation!
+  - pip
+  - pip:
+      - chai_lab==0.3.0


### PR DESCRIPTION
This PR demonstrates how to add Cuda to the environment.yml dependencies. After installing the conda environment, this _should_ meet all Cuda requirements but currently it's untested.

It still requires nvidia drivers to be passed from the host machine, see nvidia-container-toolkit documentation for further details.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/seqeralabs/nf-chai/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
