### PR TITLE
Add --weights_dir parameter to provide pre-downloaded weights to Chai-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ Special thanks to the following for their contributions to the release:
 - [PR #1](https://github.com/seqeralabs/nf-chai/pull/1) - Delete files not required from nf-core pipeline template
 - [PR #2](https://github.com/seqeralabs/nf-chai/pull/2) - Remove additional customisations from nf-core pipeline template to simplify further
 - [PR #5](https://github.com/seqeralabs/nf-chai/pull/5) - Add chai-1 functionality to the pipeline
+- [PR #8](https://github.com/seqeralabs/nf-chai/pull/8) - Add `--weights_dir` parameter to provide pre-downloaded weights to Chai-1

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ nextflow run seqeralabs/nf-chai \
    -profile <docker/singularity>
 ```
 
+Set the `--weights_dir` parameter to a location with the pre-downloaded weights required by Chai-1 to avoid having to download them every time you run the pipeline.
+
 ## Credits
 
 nf-chai was originally written by the Seqera Team.

--- a/main.nf
+++ b/main.nf
@@ -43,9 +43,7 @@ workflow {
     //
     NF_CHAI (
         params.input,
-        params.msa_dir,
-        params.constraints,
-        params.model_dir
+        params.weights_dir
     )
 
     //

--- a/modules/local/chai_1/main.nf
+++ b/modules/local/chai_1/main.nf
@@ -6,8 +6,7 @@ process CHAI_1 {
 
     input:
     tuple val(meta), path(fasta)
-    path msa_dir
-    path constraints
+    path weights_dir
 
     output:
     tuple val(meta), path("${meta.id}/*.cif"), emit: structures
@@ -15,11 +14,12 @@ process CHAI_1 {
     path "versions.yml"                      , emit: versions
 
     script:
+    def downloads_dir = weights_dir ?: './downloads'
     """
-    CHAI_DOWNLOADS_DIR=./downloads \\
+    CHAI_DOWNLOADS_DIR=$downloads_dir \\
     run_chai_1.py \\
         --output-dir ${meta.id} \\
-        --fasta-file ${fasta}
+        --fasta-file ${fasta}  
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/chai_1/main.nf
+++ b/modules/local/chai_1/main.nf
@@ -19,7 +19,7 @@ process CHAI_1 {
     CHAI_DOWNLOADS_DIR=$downloads_dir \\
     run_chai_1.py \\
         --output-dir ${meta.id} \\
-        --fasta-file ${fasta}  
+        --fasta-file ${fasta}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,9 +11,7 @@ params {
 
     // Input options
     input                        = null
-    msa_dir                      = null
-    constraints                  = null
-    model_dir                    = null
+    weights_dir                  = null
     use_gpus                     = false
 
     // Boilerplate options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -28,28 +28,11 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
-                "msa_dir": {
+                "weights_dir": {
                     "type": "string",
                     "format": "directory-path",
                     "exists": true,
-                    "description": "Directory containing MSA files.",
-                    "help_text": "If provided, should contain aligned.pqt files for the input sequences.",
-                    "fa_icon": "fas fa-folder-open"
-                },
-                "constraints": {
-                    "type": "string",
-                    "format": "file-path",
-                    "exists": true,
-                    "description": "Path to constraints file.",
-                    "help_text": "File containing structural constraints to guide the prediction.",
-                    "fa_icon": "fas fa-file"
-                },
-                "model_dir": {
-                    "type": "string",
-                    "format": "directory-path",
-                    "exists": true,
-                    "description": "Directory where model weights and other artifacts will be downloaded.",
-                    "help_text": "This directory will be used to store downloaded model weights and other required files.",
+                    "description": "Directory containing model weights and other artifacts required by Chai-1.",
                     "fa_icon": "fas fa-folder-open"
                 },
                 "use_gpus": {

--- a/workflows/nf_chai/main.nf
+++ b/workflows/nf_chai/main.nf
@@ -16,10 +16,8 @@ include { CHAI_1                 } from '../../modules/local/chai_1'
 workflow NF_CHAI {
 
     take:
-    fasta_file       //  string: path to fasta file read provided via --input parameter
-    msa_dir          //  string: path to MSA directory read provided via --msa_dir parameter
-    constraints_file //  string: path to constraints file read provided via --constraints parameter
-    model_dir        //  string: path to model directory read provided via --model_dir parameter
+    fasta_file  //  string: path to fasta file read provided via --input parameter
+    weights_dir //  string: path to model directory read provided via --weights_directory parameter
 
     main:
 
@@ -36,8 +34,7 @@ workflow NF_CHAI {
     // Run structure prediction with Chai-1
     CHAI_1 (
         ch_fasta,
-        msa_dir ? Channel.fromPath(msa_dir) : [],
-        constraints_file ? Channel.fromPath(constraints_file) : []
+        weights_dir ? Channel.fromPath(weights_dir) : []
     )
     ch_versions = ch_versions.mix(CHAI_1.out.versions)
 


### PR DESCRIPTION
Adds the ability to cache the Chai-1 weights to avoid having to download them at run-time everytime the process is executed.